### PR TITLE
Fix: LanguagePatcher writes to incorrect assembly.

### DIFF
--- a/MultiLanguage/languages/Config.json
+++ b/MultiLanguage/languages/Config.json
@@ -1,4 +1,4 @@
 {
     "LanguageName": "EN",
-    "ExecutingAssembly": "StardewModdingAPI.exe"
+    "ExecutingAssembly": "Stardew Valley.exe"
 }


### PR DESCRIPTION
I tried the latest version of this mod, and it works with SMAPI.

However the first time I tried it, it does the translation but SMAPI wrapper didn't start up. Then I realized that `StardewModdingAPI.exe` was overwritten by the patched `Stardew Valley.exe`, which is probably not we want.

This is because updated `Config.json` affects the code in `LanguagePatcher`:
https://github.com/WarFollowsMe/TranslationMod/blob/master/LanguagePatcher/Program.cs#L93

```
GameAssembly.Write(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), LocalizationBridge.Localization.Config.ExecutingAssembly));
```

I tried to change the `ExecutingAssembly` of `Config.json` back to `Stardew Valley.exe` and everything works (both translation and SMAPI mods), another way is to change the line above, but I didn't test.

---

btw, you probably wants to update `README.md` since the mod works with SMAPI now.

Signed-off-by: Wenxuan Zhao viz@linux.com
