### PR TITLE
Fix: DrawObjectQuestionDialogue() injection for 1.11.

### DIFF
--- a/LanguagePatcher/Program.cs
+++ b/LanguagePatcher/Program.cs
@@ -248,7 +248,7 @@ namespace LanguagePatcher
         }
         static void InjectDrawObjectQuestionDialogue()
         {
-            var CallbackMethod = typeof(LocalizationBridge).GetMethod("DrawObjectQuestionDialogueCallback", new Type[] { typeof(string), typeof(List<>).MakeGenericType(typeof(string)) });
+            var CallbackMethod = typeof(LocalizationBridge).GetMethod("DrawObjectQuestionDialogueCallback", new Type[] { typeof(string), typeof(List<>).MakeGenericType(typeof(object)) });
             var Callback = GameAssembly.MainModule.Import(CallbackMethod);
 
             var injectee = GameAssembly.GetMethod("StardewValley.Game1", "drawObjectQuestionDialogue", "(System.String,System.Collections.Generic.List`1)System.Void");

--- a/MultiLanguage/Localization.cs
+++ b/MultiLanguage/Localization.cs
@@ -10,12 +10,14 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using StardewValley;
 
 namespace MultiLanguage
 {
@@ -382,7 +384,7 @@ namespace MultiLanguage
             return result;
         }
 
-        public DialogueQuestion OnDrawObjectQuestionDialogue(string dialogue, List<string> choices = null)
+        public DialogueQuestion OnDrawObjectQuestionDialogue(string dialogue, List<object> choices = null)
         {
             var result = new DialogueQuestion();
             if (Config.LanguageName != "EN")
@@ -393,16 +395,24 @@ namespace MultiLanguage
                 }
                 var translateDialogue = Translate(dialogue);
                 result.Dialogue = translateDialogue;
-                result.Choices = new List<string>();
+                result.Choices = new List<object>();
                 if(choices != null)
                 {
                     foreach (var chois in choices)
                     {
-                        if (_translatedStrings.Contains(chois))
+                        var choice = chois as Response;
+                        if (choice == null)
+                        {
+                            result.Choices.Add(null);
+                            continue;
+                        }
+                        if (_translatedStrings.Contains(choice.responseText))
                         {
                             result.Choices.Add(chois);
+                            continue;
                         }
-                        var translateChois = Translate(chois);
+                        var translateChois = Translate(choice.responseText);
+                        choice.responseText = translateChois;
                         result.Choices.Add(chois);
                     }
                 }
@@ -1328,10 +1338,10 @@ namespace MultiLanguage
     public class DialogueQuestion
     {
         public string Dialogue { get; set; }
-        public List<string> Choices { get; set; }
+        public List<object> Choices { get; set; }
         public DialogueQuestion()
         {
-            Choices = new List<string>();
+            Choices = new List<object>();
         }
     }
 }

--- a/MultiLanguage/LocalizationBridge.cs
+++ b/MultiLanguage/LocalizationBridge.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
+using StardewValley;
 
 namespace MultiLanguage
 {
@@ -61,7 +62,7 @@ namespace MultiLanguage
             return result;
         }
 
-        public static DialogueQuestion DrawObjectQuestionDialogueCallback(string dialogue, List<string> choices)
+        public static DialogueQuestion DrawObjectQuestionDialogueCallback(string dialogue, List<object> choices)
         {
             return Localization.OnDrawObjectQuestionDialogue(dialogue, choices);
         }


### PR DESCRIPTION
Since signature of `DrawObjectQuestionDialogue()` for Stardew Valley version 1.11 has changed.
It crashes game when accessing shops.

Signed-off-by: Wenxuan Zhao viz@linux.com
